### PR TITLE
feature/4030 UnityからAndroidに座標を送る非同期通信

### DIFF
--- a/HOPcardAPI/domain/models/message_xyz.go
+++ b/HOPcardAPI/domain/models/message_xyz.go
@@ -1,0 +1,6 @@
+package models
+
+type XYZMessage struct {
+	X float32 `json:"x"`
+	Z float32 `json:"z"`
+}

--- a/HOPcardAPI/interfaces/handlers/difficulty_handler.go
+++ b/HOPcardAPI/interfaces/handlers/difficulty_handler.go
@@ -9,30 +9,30 @@ import (
 	"sync"
 )
 
-type WebSocketHandler struct {
-	upgrader     websocket.Upgrader
-	gameUsecase  *usecase.DifficultyUsecase
-	connections  map[string]*websocket.Conn
-	mutex        sync.RWMutex
-	androidConns map[string]bool
-	unityConns   map[string]bool
+type DifficultyWebSocketHandler struct {
+	upgrader          websocket.Upgrader
+	difficultyUsecase *usecase.DifficultyUsecase
+	connections       map[string]*websocket.Conn
+	mutex             sync.RWMutex
+	androidConns      map[string]bool
+	unityConns        map[string]bool
 }
 
-func NewWebSocketHandler(gameUsecase *usecase.DifficultyUsecase) *WebSocketHandler {
-	return &WebSocketHandler{
+func NewDifficultyWebSocketHandler(gameUsecase *usecase.DifficultyUsecase) *DifficultyWebSocketHandler {
+	return &DifficultyWebSocketHandler{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				return true // 本番環境では適切に設定する
 			},
 		},
-		gameUsecase:  gameUsecase,
-		connections:  make(map[string]*websocket.Conn),
-		androidConns: make(map[string]bool),
-		unityConns:   make(map[string]bool),
+		difficultyUsecase: gameUsecase,
+		connections:       make(map[string]*websocket.Conn),
+		androidConns:      make(map[string]bool),
+		unityConns:        make(map[string]bool),
 	}
 }
 
-func (h *WebSocketHandler) HandleAndroidWebSocket(w http.ResponseWriter, r *http.Request) {
+func (h *DifficultyWebSocketHandler) HandleAndroidWebSocket(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	uuid := vars["uuid"]
 	if uuid == "" {
@@ -65,8 +65,7 @@ func (h *WebSocketHandler) HandleAndroidWebSocket(w http.ResponseWriter, r *http
 		if err != nil {
 			break
 		}
-
-		unityMsg, err := h.gameUsecase.ProcessDifficultyData(androidMsg.Difficulty)
+		unityMsg, err := h.difficultyUsecase.ProcessDifficultyData(androidMsg.Difficulty)
 		if err != nil {
 			continue
 		}
@@ -86,7 +85,7 @@ func (h *WebSocketHandler) HandleAndroidWebSocket(w http.ResponseWriter, r *http
 	}
 }
 
-func (h *WebSocketHandler) HandleUnityWebSocket(w http.ResponseWriter, r *http.Request) {
+func (h *DifficultyWebSocketHandler) HandleUnityWebSocket(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	uuid := vars["uuid"]
 	if uuid == "" {

--- a/HOPcardAPI/interfaces/handlers/difficulty_handler.go
+++ b/HOPcardAPI/interfaces/handlers/difficulty_handler.go
@@ -11,14 +11,14 @@ import (
 
 type WebSocketHandler struct {
 	upgrader     websocket.Upgrader
-	gameUsecase  *usecase.GameUsecase
+	gameUsecase  *usecase.DifficultyUsecase
 	connections  map[string]*websocket.Conn
 	mutex        sync.RWMutex
 	androidConns map[string]bool
 	unityConns   map[string]bool
 }
 
-func NewWebSocketHandler(gameUsecase *usecase.GameUsecase) *WebSocketHandler {
+func NewWebSocketHandler(gameUsecase *usecase.DifficultyUsecase) *WebSocketHandler {
 	return &WebSocketHandler{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
@@ -66,7 +66,7 @@ func (h *WebSocketHandler) HandleAndroidWebSocket(w http.ResponseWriter, r *http
 			break
 		}
 
-		unityMsg, err := h.gameUsecase.ProcessGameData(androidMsg.Difficulty)
+		unityMsg, err := h.gameUsecase.ProcessDifficultyData(androidMsg.Difficulty)
 		if err != nil {
 			continue
 		}

--- a/HOPcardAPI/interfaces/handlers/xyz_handler.go
+++ b/HOPcardAPI/interfaces/handlers/xyz_handler.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"HOPcardAPI/domain/models"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"net/http"
+	"sync"
+)
+
+type XYZWebSocketHandler struct {
+	upgrader     websocket.Upgrader
+	connections  map[string]*websocket.Conn
+	mutex        sync.RWMutex
+	androidConns map[string]bool
+	unityConns   map[string]bool
+}
+
+// NewWebSocketHandler は新しい XYZWebSocketHandler を作成します。
+func XYZNewWebSocketHandler() *XYZWebSocketHandler {
+	return &XYZWebSocketHandler{
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true // 本番環境では適切に設定する
+			},
+		},
+		connections:  make(map[string]*websocket.Conn),
+		androidConns: make(map[string]bool),
+		unityConns:   make(map[string]bool),
+	}
+}
+
+// HandleXYZUnityWebSocket は Unity からの WebSocket 接続を処理します。
+func (h *XYZWebSocketHandler) HandleXYZUnityWebSocket(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	uuid := vars["uuid"]
+	if uuid == "" {
+		http.Error(w, "UUIDは必須です", http.StatusBadRequest)
+		return
+	}
+
+	// 接続をアップグレードする
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	// 接続をマップに追加する
+	h.mutex.Lock()
+	h.connections[uuid] = conn
+	h.unityConns[uuid] = true
+	h.mutex.Unlock()
+
+	// 接続終了時のクリーンアップ
+	defer func() {
+		h.mutex.Lock()
+		delete(h.connections, uuid)
+		delete(h.unityConns, uuid)
+		h.mutex.Unlock()
+		conn.Close()
+	}()
+
+	// メッセージの受信ループ
+	for {
+		var xyzMsg models.XYZMessage
+		err := conn.ReadJSON(&xyzMsg)
+		if err != nil {
+			break // メッセージの読み取りに失敗した場合、ループを抜ける
+		}
+
+		// Android接続が存在するか確認
+		h.mutex.RLock()
+		androidExists := h.androidConns[uuid]
+		androidConn, androidConnExists := h.connections[uuid]
+		h.mutex.RUnlock()
+
+		// Android接続が存在する場合、メッセージを転送
+		if androidExists && androidConnExists {
+			err = androidConn.WriteJSON(xyzMsg)
+			if err != nil {
+				continue // 転送に失敗した場合、次のループに進む
+			}
+		}
+	}
+}
+
+// HandleAndroidWebSocket は Android からの WebSocket 接続を処理します。
+func (h *XYZWebSocketHandler) HandleXYZAndroidWebSocket(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	uuid := vars["uuid"]
+	if uuid == "" {
+		http.Error(w, "UUIDは必須です", http.StatusBadRequest)
+		return
+	}
+
+	// 接続をアップグレードする
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	h.mutex.Lock()
+	h.connections[uuid] = conn
+	h.androidConns[uuid] = true
+	h.mutex.Unlock()
+
+	defer func() {
+		h.mutex.Lock()
+		delete(h.connections, uuid)
+		delete(h.androidConns, uuid)
+		h.mutex.Unlock()
+		conn.Close()
+	}()
+
+	for {
+		var xyzMsg models.XYZMessage
+		err := conn.ReadJSON(&xyzMsg)
+		if err != nil {
+			break // メッセージの読み取りに失敗した場合、ループを抜ける
+		}
+
+		// Unity側の接続が存在する場合、メッセージを転送
+		h.mutex.RLock()
+		unityConn, exists := h.connections[uuid]
+		isUnity := h.unityConns[uuid]
+		h.mutex.RUnlock()
+
+		if exists && isUnity {
+			err = unityConn.WriteJSON(xyzMsg)
+			if err != nil {
+				continue // 転送に失敗した場合、次のループに進む
+			}
+		}
+	}
+}

--- a/HOPcardAPI/interfaces/handlers/xyz_handler.go
+++ b/HOPcardAPI/interfaces/handlers/xyz_handler.go
@@ -10,27 +10,23 @@ import (
 
 type XYZWebSocketHandler struct {
 	upgrader     websocket.Upgrader
-	connections  map[string]*websocket.Conn
+	androidConns map[string]*websocket.Conn
+	unityConns   map[string]*websocket.Conn
 	mutex        sync.RWMutex
-	androidConns map[string]bool
-	unityConns   map[string]bool
 }
 
-// NewWebSocketHandler は新しい XYZWebSocketHandler を作成します。
 func XYZNewWebSocketHandler() *XYZWebSocketHandler {
 	return &XYZWebSocketHandler{
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
-				return true // 本番環境では適切に設定する
+				return true
 			},
 		},
-		connections:  make(map[string]*websocket.Conn),
-		androidConns: make(map[string]bool),
-		unityConns:   make(map[string]bool),
+		androidConns: make(map[string]*websocket.Conn),
+		unityConns:   make(map[string]*websocket.Conn),
 	}
 }
 
-// HandleXYZUnityWebSocket は Unity からの WebSocket 接続を処理します。
 func (h *XYZWebSocketHandler) HandleXYZUnityWebSocket(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	uuid := vars["uuid"]
@@ -39,53 +35,48 @@ func (h *XYZWebSocketHandler) HandleXYZUnityWebSocket(w http.ResponseWriter, r *
 		return
 	}
 
-	// 接続をアップグレードする
+	h.mutex.RLock()
+	_, androidExists := h.androidConns[uuid]
+	h.mutex.RUnlock()
+
+	if !androidExists {
+		http.Error(w, "No matching Android connection", http.StatusBadRequest)
+		return
+	}
+
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
 		return
 	}
 
-	// 接続をマップに追加する
 	h.mutex.Lock()
-	h.connections[uuid] = conn
-	h.unityConns[uuid] = true
+	h.unityConns[uuid] = conn
 	h.mutex.Unlock()
 
-	// 接続終了時のクリーンアップ
 	defer func() {
 		h.mutex.Lock()
-		delete(h.connections, uuid)
 		delete(h.unityConns, uuid)
 		h.mutex.Unlock()
 		conn.Close()
 	}()
 
-	// メッセージの受信ループ
 	for {
 		var xyzMsg models.XYZMessage
 		err := conn.ReadJSON(&xyzMsg)
 		if err != nil {
-			break // メッセージの読み取りに失敗した場合、ループを抜ける
+			break
 		}
 
-		// Android接続が存在するか確認
+		// Android側に転送
 		h.mutex.RLock()
-		androidExists := h.androidConns[uuid]
-		androidConn, androidConnExists := h.connections[uuid]
-		h.mutex.RUnlock()
-
-		// Android接続が存在する場合、メッセージを転送
-		if androidExists && androidConnExists {
-			err = androidConn.WriteJSON(xyzMsg)
-			if err != nil {
-				continue // 転送に失敗した場合、次のループに進む
-			}
+		if androidConn, exists := h.androidConns[uuid]; exists {
+			androidConn.WriteJSON(xyzMsg)
 		}
+		h.mutex.RUnlock()
 	}
 }
 
-// HandleAndroidWebSocket は Android からの WebSocket 接続を処理します。
 func (h *XYZWebSocketHandler) HandleXYZAndroidWebSocket(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	uuid := vars["uuid"]
@@ -94,7 +85,6 @@ func (h *XYZWebSocketHandler) HandleXYZAndroidWebSocket(w http.ResponseWriter, r
 		return
 	}
 
-	// 接続をアップグレードする
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
@@ -102,13 +92,11 @@ func (h *XYZWebSocketHandler) HandleXYZAndroidWebSocket(w http.ResponseWriter, r
 	}
 
 	h.mutex.Lock()
-	h.connections[uuid] = conn
-	h.androidConns[uuid] = true
+	h.androidConns[uuid] = conn
 	h.mutex.Unlock()
 
 	defer func() {
 		h.mutex.Lock()
-		delete(h.connections, uuid)
 		delete(h.androidConns, uuid)
 		h.mutex.Unlock()
 		conn.Close()
@@ -118,20 +106,14 @@ func (h *XYZWebSocketHandler) HandleXYZAndroidWebSocket(w http.ResponseWriter, r
 		var xyzMsg models.XYZMessage
 		err := conn.ReadJSON(&xyzMsg)
 		if err != nil {
-			break // メッセージの読み取りに失敗した場合、ループを抜ける
+			break
 		}
 
-		// Unity側の接続が存在する場合、メッセージを転送
+		// Unity側に転送
 		h.mutex.RLock()
-		unityConn, exists := h.connections[uuid]
-		isUnity := h.unityConns[uuid]
-		h.mutex.RUnlock()
-
-		if exists && isUnity {
-			err = unityConn.WriteJSON(xyzMsg)
-			if err != nil {
-				continue // 転送に失敗した場合、次のループに進む
-			}
+		if unityConn, exists := h.unityConns[uuid]; exists {
+			unityConn.WriteJSON(xyzMsg)
 		}
+		h.mutex.RUnlock()
 	}
 }

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -35,7 +35,10 @@ func main() {
 
 	//difficulty系の初期化
 	difficultyUsecase := usecase.NewDifficultyUsecase(quizRepo, actionRepo)
-	difficultyHandler := handlers.NewWebSocketHandler(difficultyUsecase)
+	difficultyHandler := handlers.NewDifficultyWebSocketHandler(difficultyUsecase)
+
+	// xyz系の初期化
+	xyzHandler := handlers.XYZNewWebSocketHandler()
 
 	// 他の初期化ここに書いてね
 
@@ -45,6 +48,8 @@ func main() {
 	r.HandleFunc("/getuuid", uuidHandler.GetUUID).Methods("GET")
 	r.HandleFunc("/ws/difficulty/android/{uuid}", difficultyHandler.HandleAndroidWebSocket)
 	r.HandleFunc("/ws/difficulty/unity/{uuid}", difficultyHandler.HandleUnityWebSocket)
+	r.HandleFunc("/ws/xyz/android/{uuid}", xyzHandler.HandleXYZAndroidWebSocket)
+	r.HandleFunc("/ws/xyz/unity/{uuid}", xyzHandler.HandleXYZUnityWebSocket)
 
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -34,7 +34,7 @@ func main() {
 	actionRepo := persistence.NewActionRepository(db)
 
 	//difficulty系の初期化
-	difficultyUsecase := usecase.NewGameUsecase(quizRepo, actionRepo)
+	difficultyUsecase := usecase.NewDifficultyUsecase(quizRepo, actionRepo)
 	difficultyHandler := handlers.NewWebSocketHandler(difficultyUsecase)
 
 	// 他の初期化ここに書いてね

--- a/HOPcardAPI/usecase/difficulty_usecase.go
+++ b/HOPcardAPI/usecase/difficulty_usecase.go
@@ -5,34 +5,38 @@ import (
 	"HOPcardAPI/domain/repositories"
 )
 
-type GameUsecase struct {
+type DifficultyUsecase struct {
 	quizRepo   repositories.QuizRepository
 	actionRepo repositories.ActionRepository
 }
 
-func NewGameUsecase(qr repositories.QuizRepository, ar repositories.ActionRepository) *GameUsecase {
-	return &GameUsecase{
+func NewDifficultyUsecase(qr repositories.QuizRepository, ar repositories.ActionRepository) *DifficultyUsecase {
+	return &DifficultyUsecase{
 		quizRepo:   qr,
 		actionRepo: ar,
 	}
 }
 
-func (u *GameUsecase) ProcessGameData(difficulty int) (*models.UnityDifficultyMessage, error) {
+func (u *DifficultyUsecase) ProcessDifficultyData(difficulty int) (*models.UnityDifficultyMessage, error) {
+	// difficultyに応じたクイズを3つ取得
 	quizzes, err := u.quizRepo.FindByDifficulty(difficulty, 3)
 	if err != nil {
 		return nil, err
 	}
 
+	// difficultyに応じたアクションを取得
 	action, err := u.actionRepo.FindOneByDifficulty(difficulty)
 	if err != nil {
 		return nil, err
 	}
 
+	// 3つの要素を持つquizIDsを作成
 	quizIDs := make([]int, len(quizzes))
 	for i, quiz := range quizzes {
 		quizIDs[i] = quiz.ID
 	}
 
+	// Unityに向けたレスポンスであるUnityDifficultyMessageを作成
 	return &models.UnityDifficultyMessage{
 		QuizIDs:  quizIDs,
 		ActionID: action.ID,


### PR DESCRIPTION
# コミット一覧
#66 
- **4020の遺物処理，名前変更**
- **名前変更まだあった**
- **XYZwebsocket大事にしよう**
- **difficulty直った**
- **xyzのwebsocket完了**

# 概要
Unity側からAndroid側に座標(X,Z)を送るようにした．
Android側出先に通信を開かないとUnity側で通信を開始できない．

Unity側
```
ws://127.0.0.1:8080/ws/xyz/unity/{uuid}
```
```
{
    "x": 13.333,
    "z": 45.123
}
```
Android側
```
ws://127.0.0.1:8080/ws/xyz/android/{uuid}
```
```
{
    "x": 13.333,
    "z": 45.123
}
```

# 実装結果
Unity側から座標を送信
<img width="1344" alt="スクリーンショット 2024-10-31 10 18 02" src="https://github.com/user-attachments/assets/ffbbc79f-5e52-49ff-a365-4cc3b22c2891">

android側で受け取れる
<img width="1347" alt="スクリーンショット 2024-10-31 10 18 08" src="https://github.com/user-attachments/assets/d353750b-c711-460d-ab6d-23f8b9ea0b3e">
