### PR TITLE
feature/4041 Quiz ActionにGPTに投げるためのdetailカラムを追加

### DIFF
--- a/HOPcardAPI/db/migrations/000004_alter_quiz_table_add_detail.down.sql
+++ b/HOPcardAPI/db/migrations/000004_alter_quiz_table_add_detail.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quizzes
+DROP COLUMN detail;

--- a/HOPcardAPI/db/migrations/000004_alter_quiz_table_add_detail.up.sql
+++ b/HOPcardAPI/db/migrations/000004_alter_quiz_table_add_detail.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quizzes
+    ADD COLUMN detail TEXT;

--- a/HOPcardAPI/db/migrations/000005_alter_action_table_add_detail.down.sql
+++ b/HOPcardAPI/db/migrations/000005_alter_action_table_add_detail.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE actions
+DROP COLUMN detail;

--- a/HOPcardAPI/db/migrations/000005_alter_action_table_add_detail.up.sql
+++ b/HOPcardAPI/db/migrations/000005_alter_action_table_add_detail.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE actions
+    ADD COLUMN detail TEXT;

--- a/HOPcardAPI/domain/models/action.go
+++ b/HOPcardAPI/domain/models/action.go
@@ -5,4 +5,5 @@ type Action struct {
 	Difficulty int    `json:"difficulty"`
 	LefSel     string `json:"lef_sel"`
 	RigSel     string `json:"rig_sel"`
+	Detail     string `json:"detail"`
 }

--- a/HOPcardAPI/domain/models/quiz.go
+++ b/HOPcardAPI/domain/models/quiz.go
@@ -6,4 +6,5 @@ type Quiz struct {
 	Difficulty int    `json:"difficulty"`
 	LefSel     string `json:"lef_sel"`
 	RigSel     string `json:"rig_sel"`
+	Detail     string `json:"detail"`
 }


### PR DESCRIPTION
QuizTBを以下のように変更
```go
package models

type Quiz struct {
	ID         int    `json:"id" gorm:"primaryKey;autoIncrement"`
	Name       string `json:"name"`
	Difficulty int    `json:"difficulty"`
	LefSel     string `json:"lef_sel"`
	RigSel     string `json:"rig_sel"`
	Detail     string `json:"detail"`
}
```


ActionTBを以下のように
```go
package models

type Action struct {
	ID         int    `json:"id" gorm:"primaryKey;autoIncrement"`
	Difficulty int    `json:"difficulty"`
	LefSel     string `json:"lef_sel"`
	RigSel     string `json:"rig_sel"`
	Detail     string `json:"detail"`
}

```