### PR TITLE
feature/4042 [Android向け]履歴画面で叩くuserdataのRESTAPIの実装 **結果を送受信するWebSocket通信とは違うので注意**

### DIFF
--- a/HOPcardAPI/db/migrations/000006_create_userdata_table.down.sql
+++ b/HOPcardAPI/db/migrations/000006_create_userdata_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_data;

--- a/HOPcardAPI/db/migrations/000006_create_userdata_table.up.sql
+++ b/HOPcardAPI/db/migrations/000006_create_userdata_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_data (
+                           id SERIAL PRIMARY KEY,
+                           uuid_id INT REFERENCES uuids(id),
+                           ratio FLOAT,
+                           distance FLOAT,
+                           change_count INT DEFAULT 0,
+                           created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                           updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);

--- a/HOPcardAPI/domain/models/userdata.go
+++ b/HOPcardAPI/domain/models/userdata.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"time"
+)
+
+type UserData struct {
+	ID          uint      `json:"id" gorm:"primaryKey;autoIncrement"`
+	UuidID      int       `json:"uuid_id" gorm:"foreignKey:UuidID;references:id"`
+	Ratio       float64   `json:"ratio"`
+	Distance    float64   `json:"distance"`
+	ChangeCount int       `json:"change_count" gorm:"default:0"`
+	CreatedAt   time.Time `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt   time.Time `json:"updated_at" gorm:"autoUpdateTime"`
+}

--- a/HOPcardAPI/domain/models/uuid.go
+++ b/HOPcardAPI/domain/models/uuid.go
@@ -7,7 +7,7 @@ import (
 )
 
 type UUID struct {
-	ID        uint           `json:"id" gorm:"primaryKey"`
+	ID        int            `json:"id" gorm:"primaryKey"`
 	UUID      string         `json:"uuid" gorm:"type:varchar(36)"`
 	Code      int            `json:"code"`
 	CreatedAt time.Time      `json:"created_at"`

--- a/HOPcardAPI/domain/repositories/userdata_repository.go
+++ b/HOPcardAPI/domain/repositories/userdata_repository.go
@@ -1,0 +1,9 @@
+package repositories
+
+import "HOPcardAPI/domain/models"
+
+type UserDataRepository interface {
+	Save(uuid string, ratio float64, distance float64) (string, error)
+	FindByUuid(uuid string) (*models.UserData, error)
+	Update(userData *models.UserData) (string, error)
+}

--- a/HOPcardAPI/infrastructure/persistence/userdata_persistence.go
+++ b/HOPcardAPI/infrastructure/persistence/userdata_persistence.go
@@ -1,0 +1,56 @@
+package persistence
+
+import (
+	"HOPcardAPI/domain/models"
+	"HOPcardAPI/domain/repositories"
+	"gorm.io/gorm"
+	"strconv"
+)
+
+type UserDataPersistence struct {
+	db *gorm.DB
+}
+
+func NewUserDataPersistence(db *gorm.DB) repositories.UserDataRepository {
+	return &UserDataPersistence{db}
+}
+
+func (p *UserDataPersistence) Save(uuid string, ratio float64, distance float64) (string, error) {
+	var uuidRecord models.UUID
+	if err := p.db.Where("uuid = ?", uuid).First(&uuidRecord).Error; err != nil {
+		return "", err
+	}
+
+	userData := models.UserData{
+		UuidID:   uuidRecord.ID,
+		Ratio:    ratio,
+		Distance: distance,
+	}
+
+	if err := p.db.Create(&userData).Error; err != nil {
+		return uuid, err
+	}
+
+	return uuid, nil
+}
+
+func (p *UserDataPersistence) FindByUuid(uuid string) (*models.UserData, error) {
+	var uuidRecord models.UUID
+	if err := p.db.Where("uuid = ?", uuid).First(&uuidRecord).Error; err != nil {
+		return nil, err
+	}
+
+	var userData models.UserData
+	if err := p.db.Where("uuid_id = ?", uuidRecord.ID).First(&userData).Error; err != nil {
+		return nil, err
+	}
+
+	return &userData, nil
+}
+
+func (p *UserDataPersistence) Update(userData *models.UserData) (string, error) {
+	if err := p.db.Save(userData).Error; err != nil {
+		return "", err
+	}
+	return strconv.Itoa(userData.UuidID), nil // uuidを返す
+}

--- a/HOPcardAPI/interfaces/handlers/userdata_handler.go
+++ b/HOPcardAPI/interfaces/handlers/userdata_handler.go
@@ -54,7 +54,6 @@ func (h *UserDataHandler) GetUserData(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := map[string]interface{}{
-		"uuid":         uuid,
 		"ratio":        userData.Ratio,
 		"distance":     userData.Distance,
 		"change_count": userData.ChangeCount,

--- a/HOPcardAPI/interfaces/handlers/userdata_handler.go
+++ b/HOPcardAPI/interfaces/handlers/userdata_handler.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"HOPcardAPI/usecase"
+	"encoding/json"
+	"net/http"
+)
+
+type UserDataHandler struct {
+	userDataUseCase usecase.UserDataUsecase
+}
+
+func NewUserDataHandler(uc usecase.UserDataUsecase) *UserDataHandler {
+	return &UserDataHandler{userDataUseCase: uc}
+}
+
+type createUserDataRequest struct {
+	Uuid     string  `json:"uuid"`
+	Ratio    float64 `json:"ratio"`
+	Distance float64 `json:"distance"`
+}
+
+func (h *UserDataHandler) CreateUserData(w http.ResponseWriter, r *http.Request) {
+	var req createUserDataRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	uuid, err := h.userDataUseCase.SaveUserData(req.Uuid, req.Ratio, req.Distance)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// UUIDをレスポンスとして返す
+	response := map[string]string{"uuid": uuid}
+	w.WriteHeader(http.StatusCreated)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *UserDataHandler) GetUserData(w http.ResponseWriter, r *http.Request) {
+	uuid := r.URL.Query().Get("uuid")
+	if uuid == "" {
+		http.Error(w, "Missing uuid parameter", http.StatusBadRequest)
+		return
+	}
+
+	userData, err := h.userDataUseCase.GetUserDataByUuid(uuid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	response := map[string]interface{}{
+		"uuid":         uuid,
+		"ratio":        userData.Ratio,
+		"distance":     userData.Distance,
+		"change_count": userData.ChangeCount,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -40,6 +40,11 @@ func main() {
 	// xyz系の初期化
 	xyzHandler := handlers.XYZNewWebSocketHandler()
 
+	// userdata系の初期化
+	userdataRepo := persistence.NewUserDataPersistence(db)
+	userdataUseCase := usecase.NewUserDataUsecase(userdataRepo)
+	userdataHandler := handlers.NewUserDataHandler(*userdataUseCase)
+
 	// 他の初期化ここに書いてね
 
 	// ルーティング
@@ -50,6 +55,8 @@ func main() {
 	r.HandleFunc("/ws/difficulty/unity/{uuid}", difficultyHandler.HandleUnityWebSocket)
 	r.HandleFunc("/ws/xyz/android/{uuid}", xyzHandler.HandleXYZAndroidWebSocket)
 	r.HandleFunc("/ws/xyz/unity/{uuid}", xyzHandler.HandleXYZUnityWebSocket)
+	r.HandleFunc("/createuserdata", userdataHandler.CreateUserData).Methods("POST")
+	r.HandleFunc("/getuserdata", userdataHandler.GetUserData).Methods("GET")
 
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/HOPcardAPI/usecase/userdata_usecase.go
+++ b/HOPcardAPI/usecase/userdata_usecase.go
@@ -1,0 +1,39 @@
+package usecase
+
+import (
+	"HOPcardAPI/domain/models"
+	"HOPcardAPI/domain/repositories"
+)
+
+type UserDataUsecase struct {
+	repo repositories.UserDataRepository
+}
+
+func NewUserDataUsecase(repo repositories.UserDataRepository) *UserDataUsecase {
+	return &UserDataUsecase{repo}
+}
+
+func (uc *UserDataUsecase) SaveUserData(uuid string, ratio float64, distance float64) (string, error) {
+	userData, err := uc.repo.FindByUuid(uuid)
+	if err != nil {
+		// データが存在しない場合は新規作成
+		return uc.repo.Save(uuid, ratio, distance)
+	}
+
+	// データが存在する場合の処理
+	// TODO:計算過程合ってるかチェック
+	newRatio := (userData.Ratio + float64(userData.ChangeCount+1)*ratio) / float64(userData.ChangeCount+2)
+	newDistance := userData.Distance + distance
+	newChangeCount := userData.ChangeCount + 1
+
+	userData.Ratio = newRatio
+	userData.Distance = newDistance
+	userData.ChangeCount = newChangeCount
+
+	// 更新処理を行う
+	return uc.repo.Update(userData)
+}
+
+func (uc *UserDataUsecase) GetUserDataByUuid(uuid string) (*models.UserData, error) {
+	return uc.repo.FindByUuid(uuid)
+}


### PR DESCRIPTION
# 概要
ユーザの認知度(ratio)，歩いた距離(distance)，データを変更した回数(=遊んだ回数 - 1)(change_count)，を格納するuserdataテーブルの作成とGET，POST(自動PUT)の作成

# 仕様
## データの登録(POST)
エンドポイント
```
/createuserdata
```
リクエストボディ
```
{
    "uuid": "de158130-e94a-5192-8bb9-d27007ad1944",
    "ratio": 0.1,
    "distance": 100.0
}
```
レスポンス(フロントでは無視していいよ)
初回登録
```
{
    "uuid": "de158130-e94a-5192-8bb9-d27007ad1944"
}
```
このPOSTはPUTも兼ねていて，もしテーブルにPOSTとし送ったuuidがテーブルに存在するならPUTとしてデータの更新をするようにしている．
その際のレスポンス(uuidって名前で変えてきているけど実際はuuid_id)
```
{
    "uuid":"1"
}
```

### フロントの皆さんへ
POSTに関しては**フロント側で実行することはない**んで無視してください．
`ws/result/unity/{uuid}`でのwebsocket通信で結果を送る際に**サーバー側で勝手に実行**されます
#74 ←こっちのwebsocket通信のことね

## データの取得(GET)
エンドポイント
```
/getuserdata
```
クエリパラメータ
```
?uuid=de158130-e94a-5192-8bb9-d27007ad1944
```
> [!IMPORTANT]
> 今更やけどクエリパラメータにダブルクオーテーション("")を入れないでね

レスポンス
```
{
    "change_count": 5,
    "distance": 600,
    "ratio": 0.08333333333333333,
}
```

GETに関してはAndroid側で叩くので確認しておいてね

> [!WARNING]
> バックエンドとしてこの後作成する結果のWebsocke通信と今回実装したuserdataのRESTAPIは違うものなんで注意．結果のWebsocke通信はAndroidのゲーム画面で受け取るデータで今回実装したuserdataのRESTAPIは履歴画面で受け取るデータですよ！！！！！#74 ←こっちのwebsocket通信のことね



