### PR TITLE
feature/4043 結果送信Websocket通信 & GPT講評機能

### DIFF
--- a/HOPcardAPI/domain/models/message_result.go
+++ b/HOPcardAPI/domain/models/message_result.go
@@ -8,7 +8,9 @@ type ResultUnityMessage struct {
 }
 
 type ResultAndroidMessage struct {
-	Cor      []bool  `json:"cor"`
-	Distance float64 `json:"distance"`
-	Message  string  `json:"message"`
+	QuizNames  []string `json:"quiz_names"`
+	Difficulty string   `json:"difficulty"`
+	Cor        []bool   `json:"cor"`
+	Distance   float64  `json:"distance"`
+	Message    string   `json:"message"`
 }

--- a/HOPcardAPI/domain/models/message_result.go
+++ b/HOPcardAPI/domain/models/message_result.go
@@ -1,0 +1,14 @@
+package models
+
+type ResultUnityMessage struct {
+	QuizID   []int   `json:"quiz_id"`
+	ActionID int     `json:"action_id"`
+	Cor      []bool  `json:"cor"`
+	Distance float64 `json:"distance"`
+}
+
+type ResultAndroidMessage struct {
+	Cor      []bool  `json:"cor"`
+	Distance float64 `json:"distance"`
+	Message  string  `json:"message"`
+}

--- a/HOPcardAPI/domain/repositories/action_repository.go
+++ b/HOPcardAPI/domain/repositories/action_repository.go
@@ -4,4 +4,5 @@ import "HOPcardAPI/domain/models"
 
 type ActionRepository interface {
 	FindOneByDifficulty(difficulty int) (*models.Action, error)
+	FindOneByID(id int) (*models.Action, error)
 }

--- a/HOPcardAPI/domain/repositories/quiz_repositpry.go
+++ b/HOPcardAPI/domain/repositories/quiz_repositpry.go
@@ -1,7 +1,10 @@
 package repositories
 
-import "HOPcardAPI/domain/models"
+import (
+	"HOPcardAPI/domain/models"
+)
 
 type QuizRepository interface {
 	FindByDifficulty(difficulty int, limit int) ([]models.Quiz, error)
+	FindByID(id int) (models.Quiz, error)
 }

--- a/HOPcardAPI/infrastructure/persistence/action_persistence.go
+++ b/HOPcardAPI/infrastructure/persistence/action_persistence.go
@@ -19,3 +19,9 @@ func (r *actionRepository) FindOneByDifficulty(difficulty int) (*models.Action, 
 	err := r.db.Where("difficulty = ?", difficulty).First(&action).Error
 	return &action, err
 }
+
+func (r *actionRepository) FindOneByID(id int) (*models.Action, error) {
+	var action models.Action
+	err := r.db.Where("id = ?", id).First(&action).Error
+	return &action, err
+}

--- a/HOPcardAPI/infrastructure/persistence/quiz_persistence.go
+++ b/HOPcardAPI/infrastructure/persistence/quiz_persistence.go
@@ -19,3 +19,9 @@ func (r *quizRepository) FindByDifficulty(difficulty int, limit int) ([]models.Q
 	err := r.db.Where("difficulty = ?", difficulty).Limit(limit).Find(&quizzes).Error
 	return quizzes, err
 }
+
+func (r *quizRepository) FindByID(id int) (models.Quiz, error) {
+	var quiz models.Quiz
+	err := r.db.Where("id = ?", id).First(&quiz).Error
+	return quiz, err
+}

--- a/HOPcardAPI/interfaces/handlers/result_handler.go
+++ b/HOPcardAPI/interfaces/handlers/result_handler.go
@@ -1,0 +1,291 @@
+package handlers
+
+import (
+	"HOPcardAPI/domain/models"
+	"HOPcardAPI/domain/repositories"
+	"HOPcardAPI/usecase"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+)
+
+type ResultWebSocketHandler struct {
+	upgrader           websocket.Upgrader
+	androidConns       map[string]*websocket.Conn
+	unityConns         map[string]*websocket.Conn
+	mutex              sync.RWMutex
+	quizRepository     repositories.QuizRepository
+	userDataRepository repositories.UserDataRepository
+	userusecase        *usecase.UserDataUsecase
+}
+
+// ResultNewWebSocketHandler は、Unity側とAndroid側のWebSocket接続を管理するハンドラーを生成する
+func ResultNewWebSocketHandler(quizRepo repositories.QuizRepository, userDataRepo repositories.UserDataRepository, userUsecase *usecase.UserDataUsecase) *ResultWebSocketHandler {
+	return &ResultWebSocketHandler{
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+		androidConns:       make(map[string]*websocket.Conn),
+		unityConns:         make(map[string]*websocket.Conn),
+		quizRepository:     quizRepo,
+		userDataRepository: userDataRepo,
+		userusecase:        userUsecase,
+	}
+}
+
+// HandleResultUnityWebSocket は、Unity側からのWebSocket接続要求を処理する
+func (h *ResultWebSocketHandler) HandleResultUnityWebSocket(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	uuid := vars["uuid"]
+	if uuid == "" {
+		http.Error(w, "UUIDは必須です", http.StatusBadRequest)
+		return
+	}
+
+	// Android側の接続を確認する
+	h.mutex.RLock()
+	_, androidExists := h.androidConns[uuid]
+	h.mutex.RUnlock()
+	if !androidExists {
+		http.Error(w, "No matching Android connection", http.StatusBadRequest)
+		return
+	}
+
+	// Unity側の接続を確立する
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("接続のアップグレードに失敗しました : %v", err)
+		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
+		return
+	}
+	h.mutex.Lock()
+	h.unityConns[uuid] = conn
+	h.mutex.Unlock()
+
+	defer func() {
+		h.mutex.Lock()
+		delete(h.unityConns, uuid)
+		h.mutex.Unlock()
+		conn.Close() // 接続を閉じる
+	}()
+
+	for {
+		var resultMsg models.ResultUnityMessage
+		err := conn.ReadJSON(&resultMsg)
+		if err != nil {
+			log.Printf("Unity側からの受信に失敗しました: %v", err)
+			break
+		}
+
+		log.Printf("Unity側からのメッセージを受信しました: %v", resultMsg)
+		// ユーザーデータの格納処理
+		ratio := float64(countTrue(resultMsg.Cor)) / float64(len(resultMsg.Cor))
+		userData := models.UserData{
+			Ratio:    ratio,
+			Distance: resultMsg.Distance,
+		}
+
+		// ユーザーデータをデータベースに保存
+		if err, _ := h.userusecase.SaveUserData(uuid, userData.Ratio, userData.Distance); err == "" {
+			log.Printf("ユーザーデータの保存に失敗しました: %v", err)
+			continue
+		}
+
+		// ChatGPTへのプロンプトを準備
+		prompts, err := h.buildChatGPTPrompt(resultMsg.QuizID, resultMsg.Cor)
+		if err != nil {
+			log.Printf("ChatGPTプロンプト作成に失敗しました: %v", err)
+			continue
+		}
+		prompt := fmt.Sprintf("以下のデータは高齢者向けの認知症予防の問題を解いた結果で，Difficultyは問題の難易度，Nameは問題名，Detailは問題の説明でどのようなジャンルの問題かを示しています．:\n%s", strings.Join(prompts, "\n"))
+		log.Println("生成されたプロンプト:", prompt)
+
+		// ChatGPTに問い合わせ
+		chatGPTResponse, err := AskChatGPT(prompt)
+		if err != nil {
+			log.Printf("ChatGPT呼び出しに失敗しました: %v", err)
+			continue
+		}
+		log.Printf("ChatGPTからの応答: %s", chatGPTResponse)
+
+		//Android側にデータを送信
+		resultAndroidMsg := models.ResultAndroidMessage{
+			Cor:      resultMsg.Cor,
+			Distance: resultMsg.Distance,
+			Message:  chatGPTResponse,
+		}
+		h.mutex.RLock()
+		if androidConn, exists := h.androidConns[uuid]; exists {
+			err := androidConn.WriteJSON(resultAndroidMsg)
+			if err != nil {
+				log.Printf("Android側への送信に失敗しました: %v", err)
+			}
+		}
+		h.mutex.RUnlock()
+	}
+}
+
+// buildChatGPTPrompt は、問題の詳細情報を元にChatGPTへのプロンプトを作成する
+func (h *ResultWebSocketHandler) buildChatGPTPrompt(quizIDs []int, cor []bool) ([]string, error) {
+	fmt.Printf("quizIDs: %v\n", quizIDs)
+	var prompts []string
+	for i, quizID := range quizIDs {
+		quiz, err := h.quizRepository.FindByID(quizID)
+		if err != nil {
+			return nil, fmt.Errorf("問題の取得に失敗しました: %v", err)
+		}
+
+		// Difficultyを人間が理解しやすい形式に変換
+		difficultyStr := "Unknown"
+		switch quiz.Difficulty {
+		case 1:
+			difficultyStr = "簡単"
+		case 2:
+			difficultyStr = "ふつう"
+		case 3:
+			difficultyStr = "難しい"
+		}
+
+		// corを元に正解不正解を表現
+		correctness := "不正解"
+		if cor[i] {
+			correctness = "正解"
+		}
+
+		log.Printf("prompt: %s", fmt.Sprintf("Difficulty: %s, Name: %s, Detail: %s, %s"))
+
+		prompts = append(prompts, fmt.Sprintf("Difficulty: %s, Name: %s, Detail: %s, %s",
+			difficultyStr, quiz.Name, quiz.Detail, correctness))
+	}
+	correctness := "不正解"
+	if cor[len(cor)-1] {
+		correctness = "正解"
+	}
+	prompts = append(prompts, fmt.Sprintf("\n 運動中や途中のクイズの間に出現した犬の数を数える問題は %sでした．この問題は注意力を問う問題です．この認知症予防の問題3問と注意力を問う問題から高齢者向けの認知症予防の観点で評価とアドバイスを2文以内で簡潔に評価してください．主語を「あなた」で答えてください．", correctness))
+
+	return prompts, nil
+}
+
+// countTrue は、boolの配列からtrueの数をカウントする
+func countTrue(cor []bool) int {
+	count := 0
+	for _, v := range cor {
+		if v {
+			count++
+		}
+	}
+	return count
+}
+
+// HandleResultAndroidWebSocket は、Android側からのWebSocket接続要求を処理する
+func (h *ResultWebSocketHandler) HandleResultAndroidWebSocket(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	uuid := vars["uuid"]
+	if uuid == "" {
+		http.Error(w, "UUIDは必須です", http.StatusBadRequest)
+		return
+	}
+
+	// Android側の接続を確立する
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("接続のアップグレードに失敗しました: %v", err)
+		http.Error(w, "接続のアップグレードに失敗しました", http.StatusInternalServerError)
+		return
+	}
+	h.mutex.Lock()
+	h.androidConns[uuid] = conn
+	h.mutex.Unlock()
+
+	defer func() {
+		h.mutex.Lock()
+		delete(h.androidConns, uuid)
+		h.mutex.Unlock()
+		conn.Close() // 接続を閉じる
+	}()
+
+	for {
+		var resultMsg models.ResultAndroidMessage
+		err := conn.ReadJSON(&resultMsg)
+		if err != nil {
+			log.Printf("Android側からの受信に失敗しました: %v", err)
+			break
+		}
+
+		// Unity側に結果を転送する
+		h.mutex.RLock()
+		if unityConn, exists := h.unityConns[uuid]; exists {
+			err := unityConn.WriteJSON(resultMsg)
+			if err != nil {
+				log.Printf("Unity側への送信に失敗しました: %v", err)
+			}
+		}
+		h.mutex.RUnlock()
+	}
+}
+
+const url = "https://api.openai.com/v1/chat/completions"
+
+// AskChatGPT は、与えられたプロンプトに基づいてChatGPTに問い合わせを行う関数です。
+func AskChatGPT(prompt string) (string, error) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	requestBody := map[string]interface{}{
+		"model": "gpt-3.5-turbo",
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+		"max_tokens": 200,
+	}
+
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("リクエストボディのマーシャルに失敗しました: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("リクエストの作成に失敗しました: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("リクエストの実行に失敗しました: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("リクエストが失敗しました: %s", resp.Status)
+	}
+
+	var responseBody struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		return "", fmt.Errorf("レスポンスのデコードに失敗しました: %v", err)
+	}
+
+	if len(responseBody.Choices) == 0 {
+		return "", fmt.Errorf("レスポンスにチョイスがありません")
+	}
+
+	return responseBody.Choices[0].Message.Content, nil
+}

--- a/HOPcardAPI/interfaces/handlers/result_handler.go
+++ b/HOPcardAPI/interfaces/handlers/result_handler.go
@@ -194,7 +194,7 @@ func (h *ResultWebSocketHandler) buildChatGPTPrompt(quizIDs []int, actionID int,
 	if cor[len(cor)-1] {
 		correctness = "正解"
 	}
-	prompts = append(prompts, fmt.Sprintf("\n 運動中や途中のクイズの間に出現した犬の数を数える問題は %sで，難易度は %sでした．この問題は注意力を問う問題です．この認知症予防の問題3問と注意力を問う問題から高齢者向けの認知症予防の観点で評価とアドバイスを2文以内で簡潔に評価してください．主語を「あなた」で答えてください．", correctness, difficultyStr))
+	prompts = append(prompts, fmt.Sprintf("\n 運動中や途中のクイズの間に出現した犬の数を数える問題は %sで，難易度は %sでした．この問題は注意力を問う問題です．この認知症予防の問題3問と注意力を問う問題から高齢者向けの認知症予防の観点で評価とアドバイスを問題名を使わずに2文以内で簡潔に評価してください．主語を「あなた」で答えてください．", correctness, difficultyStr))
 
 	return prompts, quiznames, difficultyStr, nil
 }

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -45,6 +45,9 @@ func main() {
 	userdataUseCase := usecase.NewUserDataUsecase(userdataRepo)
 	userdataHandler := handlers.NewUserDataHandler(*userdataUseCase)
 
+	// result系の初期化
+	resultHandler := handlers.ResultNewWebSocketHandler(quizRepo, userdataRepo, userdataUseCase)
+
 	// 他の初期化ここに書いてね
 
 	// ルーティング
@@ -57,6 +60,8 @@ func main() {
 	r.HandleFunc("/ws/xyz/unity/{uuid}", xyzHandler.HandleXYZUnityWebSocket)
 	r.HandleFunc("/createuserdata", userdataHandler.CreateUserData).Methods("POST")
 	r.HandleFunc("/getuserdata", userdataHandler.GetUserData).Methods("GET")
+	r.HandleFunc("/ws/result/android/{uuid}", resultHandler.HandleResultAndroidWebSocket)
+	r.HandleFunc("/ws/result/unity/{uuid}", resultHandler.HandleResultUnityWebSocket)
 
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -46,7 +46,7 @@ func main() {
 	userdataHandler := handlers.NewUserDataHandler(*userdataUseCase)
 
 	// result系の初期化
-	resultHandler := handlers.ResultNewWebSocketHandler(quizRepo, userdataRepo, userdataUseCase)
+	resultHandler := handlers.ResultNewWebSocketHandler(quizRepo, actionRepo, userdataRepo, userdataUseCase)
 
 	// 他の初期化ここに書いてね
 


### PR DESCRIPTION
ガチでむずかった．過去最大級
# コミット一覧
- [GPT機能結果送信Websocket完了](https://github.com/anshibagundan/AruCo/pull/74/commits/042f9e3a289f0fd2ee3fcaee1b61063fac2fb3e8)
- [APIKEYをenvに](https://github.com/anshibagundan/AruCo/pull/74/commits/bae5e53ad63a95dfda9dd79c23b0a35acb61a03a)
- [androidにquiznames difficultをかえした](https://github.com/anshibagundan/AruCo/pull/74/commits/347fe4171254bf561f7c8f3016b7ee0864c41332)

# 概要
Unity側からquizid(int[])，actionid(id)，cor(Quiz Actionの正解不正解)，distance(VR空間で歩いた距離)を送信する．
サーバー側でuserdataテーブル(ユーザーの認知度の平均や歩いた距離の合計を記録する)を更新し，さらに1回分のゲームの結果からChatGPT(3.5-turbo)の講評を出す処理をする．
Android側へは**quizname(string[])**，**difficult(最初に選んだ難易度)(string)**，cor(Quiz Actionの正解不正解)，distance，message(chatGPTの講評)を送信する．

> difficultは最初に送ったidが1なら"簡単"，2なら"ふつう"，3なら"難しい"にしてます
# 仕様
## Unityからサーバーに送信
エンドポイント
```
/ws/result/unity/{uuid}
```
送信するデータ
```
{
    "quiz_id": [1, 2, 3],
    "action_id": 1,
    "cor": [true, false, true, false],
    "distance": 42.5
}
```
> corは0-2番目がQuizの結果，3番目がActionの結果を順番に格納してね

## サーバーからAndroidへの送信
エンドポイント
```
/ws/result/android/{uuid}
```
受信するデータ
```
 {
  "quiz_names":["1+1","地球の周りを回っているものは？","ニュートンの運動方程式は？"],
  "difficulty":"簡単",
  "cor":[true,false,true,false],
  "distance":42.5,
  "message":"あなたの注意力は十分であり、認知症予防の問題にも問題なく取り組めることができます。ただし、地球の周りを回っているものは何かという常識的な問題にはもう少し注意を払う必要があります。"
}
```
> 一応android側へはquiz_names(string[])やdifficulty(string)つけといたし，使いたかったらよろしく

# 実行結果
unity→サーバー
<img width="1316" alt="スクリーンショット 2024-11-01 9 14 04" src="https://github.com/user-attachments/assets/3b0a0a07-577a-43d3-a192-21353edc56c6">

サーバー→Android
<img width="1298" alt="スクリーンショット 2024-11-01 9 15 16" src="https://github.com/user-attachments/assets/f7447b8d-8d80-4b5a-97c1-9e525f5f9b5c">

> difficulty がstring[]のdifficultiesになってるけど気にしないで，difficult (string)があってるから
