### PR TITLE
feature/4050 [Unity側向け]Quiz Actionの名前，選択肢の取得

### DIFF
--- a/HOPcardAPI/domain/repositories/quiz_repositpry.go
+++ b/HOPcardAPI/domain/repositories/quiz_repositpry.go
@@ -6,5 +6,5 @@ import (
 
 type QuizRepository interface {
 	FindByDifficulty(difficulty int, limit int) ([]models.Quiz, error)
-	FindByID(id int) (models.Quiz, error)
+	FindByID(id int) (*models.Quiz, error)
 }

--- a/HOPcardAPI/infrastructure/persistence/quiz_persistence.go
+++ b/HOPcardAPI/infrastructure/persistence/quiz_persistence.go
@@ -20,8 +20,8 @@ func (r *quizRepository) FindByDifficulty(difficulty int, limit int) ([]models.Q
 	return quizzes, err
 }
 
-func (r *quizRepository) FindByID(id int) (models.Quiz, error) {
+func (r *quizRepository) FindByID(id int) (*models.Quiz, error) {
 	var quiz models.Quiz
 	err := r.db.Where("id = ?", id).First(&quiz).Error
-	return quiz, err
+	return &quiz, err
 }

--- a/HOPcardAPI/interfaces/handlers/action_handler.go
+++ b/HOPcardAPI/interfaces/handlers/action_handler.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"HOPcardAPI/usecase"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+type ActionHandler struct {
+	actionUseCase usecase.ActionUseCase
+}
+
+func NewActionHandler(uc usecase.ActionUseCase) *ActionHandler {
+	return &ActionHandler{actionUseCase: uc}
+}
+
+type ActionRequest struct {
+	LefSel string `json:"lef_sel"`
+	RigSel string `json:"rig_sel"`
+}
+
+func (h *ActionHandler) GetAction(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "Invalid id parameter", http.StatusBadRequest)
+		return
+	}
+
+	action, err := h.actionUseCase.GetActionByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	req := ActionRequest{
+		LefSel: action.LefSel,
+		RigSel: action.RigSel,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/HOPcardAPI/interfaces/handlers/quiz_handler.go
+++ b/HOPcardAPI/interfaces/handlers/quiz_handler.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"HOPcardAPI/usecase"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+type QuizHandler struct {
+	quizUseCase usecase.QuizUseCase
+}
+
+func NewQuizHandler(uc usecase.QuizUseCase) *QuizHandler {
+	return &QuizHandler{quizUseCase: uc}
+}
+
+type QuizRequest struct {
+	Question string `json:"Question"`
+	Lef_sel  string `json:"lef_sel"`
+	Rig_sel  string `json:"rig_sel"`
+}
+
+func (h *QuizHandler) GetQuiz(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil {
+		http.Error(w, "Invalid id parameter", http.StatusBadRequest)
+	}
+
+	quiz, err := h.quizUseCase.GetQuizByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	req := QuizRequest{
+		Question: quiz.Name,
+		Lef_sel:  quiz.LefSel,
+		Rig_sel:  quiz.RigSel,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/HOPcardAPI/main.go
+++ b/HOPcardAPI/main.go
@@ -32,6 +32,10 @@ func main() {
 	//quiz,action系の初期化
 	quizRepo := persistence.NewQuizRepository(db)
 	actionRepo := persistence.NewActionRepository(db)
+	quizUsecase := usecase.NewQuizUseCase(quizRepo)
+	actionUsecase := usecase.NewActionUseCase(actionRepo)
+	quizHandler := handlers.NewQuizHandler(quizUsecase)
+	actionHandler := handlers.NewActionHandler(actionUsecase)
 
 	//difficulty系の初期化
 	difficultyUsecase := usecase.NewDifficultyUsecase(quizRepo, actionRepo)
@@ -62,6 +66,8 @@ func main() {
 	r.HandleFunc("/getuserdata", userdataHandler.GetUserData).Methods("GET")
 	r.HandleFunc("/ws/result/android/{uuid}", resultHandler.HandleResultAndroidWebSocket)
 	r.HandleFunc("/ws/result/unity/{uuid}", resultHandler.HandleResultUnityWebSocket)
+	r.HandleFunc("/getquiz", quizHandler.GetQuiz).Methods("GET")
+	r.HandleFunc("/getaction", actionHandler.GetAction).Methods("GET")
 
 	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/HOPcardAPI/usecase/action_usecase.go
+++ b/HOPcardAPI/usecase/action_usecase.go
@@ -1,0 +1,28 @@
+package usecase
+
+import (
+	"HOPcardAPI/domain/models"
+	"HOPcardAPI/domain/repositories"
+)
+
+type ActionUseCase interface {
+	GetActionByID(id int) (*models.Action, error)
+}
+
+type actionUseCase struct {
+	actionRepository repositories.ActionRepository
+}
+
+func NewActionUseCase(actionrepo repositories.ActionRepository) ActionUseCase {
+	return &actionUseCase{
+		actionRepository: actionrepo,
+	}
+}
+
+func (uc *actionUseCase) GetActionByID(id int) (*models.Action, error) {
+	action, err := uc.actionRepository.FindOneByID(id)
+	if err != nil {
+		return nil, err
+	}
+	return action, nil
+}

--- a/HOPcardAPI/usecase/quiz_usecase.go
+++ b/HOPcardAPI/usecase/quiz_usecase.go
@@ -1,0 +1,28 @@
+package usecase
+
+import (
+	"HOPcardAPI/domain/models"
+	"HOPcardAPI/domain/repositories"
+)
+
+type QuizUseCase interface {
+	GetQuizByID(code int) (*models.Quiz, error)
+}
+
+type quizUseCase struct {
+	quizRepository repositories.QuizRepository
+}
+
+func NewQuizUseCase(quizrepo repositories.QuizRepository) QuizUseCase {
+	return &quizUseCase{
+		quizRepository: quizrepo,
+	}
+}
+
+func (uc *quizUseCase) GetQuizByID(id int) (*models.Quiz, error) {
+	quiz, err := uc.quizRepository.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	return quiz, nil
+}


### PR DESCRIPTION
# 概要
Unity側でquiz_idまたはaction_idをクエリパラメータに持たせたら，名前と選択肢が返ってくる関数を実装．

# 仕様
## QuizidからQuizデータを取得したい
エンドポイント
```bash
/getquiz
```
クエリパラメータ
```bash
?id=1
```
レスポンス
```json
{
    "Question": "1+1",
    "lef_sel": "test3",
    "rig_sel": "test4"
}
```

## ActionidからActionデータを取得したい
エンドポイント
```bash
\getaction
```
クエリパラメータ
```bash
?id=1
```
レスポンス
```json
{
    "lef_sel": "test1",
    "rig_sel": "test2"
}
```

laf_selは左選択肢，rig_selは右選択肢

