### PR TITLE
feature/4072 [Unity向け]サーバー側で一意のコードを生成してUnity側にCodeとUUIDを返すようにした

### DIFF
--- a/HOPcardAPI/interfaces/handlers/uuid_handler.go
+++ b/HOPcardAPI/interfaces/handlers/uuid_handler.go
@@ -16,28 +16,9 @@ func NewUUIDHandler(uc usecase.UUIDUseCase) *UUIDHandler {
 	return &UUIDHandler{uuidUseCase: uc}
 }
 
-type createUUIDRequest struct {
-	Code int `json:"code"`
-}
-
 func (h *UUIDHandler) CreateUUID(w http.ResponseWriter, r *http.Request) {
-	var req createUUIDRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	uuid, err := h.uuidUseCase.CreateUUID(req.Code)
+	uuid, err := h.uuidUseCase.CreateUUID()
 	if err != nil {
-		if err.Error() == "code already exists" {
-			// 既存のコードの場合は409 Conflictを返す
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{
-				"error": "Code already exists",
-			})
-			return
-		}
-		// その他のエラーは500 Internal Server Error
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/HOPcardAPI/usecase/uuid_usecase.go
+++ b/HOPcardAPI/usecase/uuid_usecase.go
@@ -4,10 +4,11 @@ import (
 	"HOPcardAPI/domain/models"
 	"HOPcardAPI/domain/repositories"
 	"HOPcardAPI/domain/services"
+	"math/rand"
 )
 
 type UUIDUseCase interface {
-	CreateUUID(code int) (*models.UUID, error)
+	CreateUUID() (*models.UUID, error)
 	GetUUIDByCode(code int) (*models.UUID, error)
 }
 
@@ -23,7 +24,25 @@ func NewUUIDUseCase(repo repositories.UUIDRepository, service services.UUIDServi
 	}
 }
 
-func (uc *uuidUseCase) CreateUUID(code int) (*models.UUID, error) {
+func (uc *uuidUseCase) CreateUUID() (*models.UUID, error) {
+	var code int
+
+	// 一意な6桁のコードが生成されるまでループ
+	for {
+		// 6桁のランダムなコードを生成 (100000から999999の範囲)
+		code = 100000 + rand.Intn(900000)
+
+		// 生成したコードが既に存在するかを確認
+		uuid, err := uc.uuidRepo.FindByCode(code)
+		if err != nil {
+			return nil, err
+		}
+		if uuid.Code != code {
+			break // 一意なコードが見つかったらループを抜ける
+		}
+	}
+
+	// UUIDを生成し、データベースに保存
 	generatedUUID := uc.uuidService.GenerateUUID(code)
 	uuid := &models.UUID{
 		UUID: generatedUUID,


### PR DESCRIPTION
## 仕様
UUIDの生成方法を変更しました．

エンドポイント
```
/createuuid
```
リクエストボディ
```
なし
```
> 元々はUnity側で6桁コードを生成していましたがサーバーで生成するようにしたのでUnity側で生成しなくていいです．

レスポンス
```
{
    "uuid": "d4f1108c-4e48-57f3-91b6-8bf7411a6db6",
    "code": 567438
}
```

