### PR TITLE
feature/4073 [Android向け]ws/difficult/androidでAndroid側にもQuizidとActionを返すようにした

### DIFF
--- a/HOPcardAPI/interfaces/handlers/difficulty_handler.go
+++ b/HOPcardAPI/interfaces/handlers/difficulty_handler.go
@@ -84,7 +84,7 @@ func (h *DifficultyWebSocketHandler) HandleAndroidWebSocket(w http.ResponseWrite
 		}
 		h.mutex.RUnlock()
 
-		// Android側には受信確認のみ送信
+		// Android側にもメッセージを送信
 		err = conn.WriteJSON(unityMsg)
 		if err != nil {
 			continue

--- a/HOPcardAPI/interfaces/handlers/difficulty_handler.go
+++ b/HOPcardAPI/interfaces/handlers/difficulty_handler.go
@@ -85,8 +85,7 @@ func (h *DifficultyWebSocketHandler) HandleAndroidWebSocket(w http.ResponseWrite
 		h.mutex.RUnlock()
 
 		// Android側には受信確認のみ送信
-		confirmMsg := map[string]string{"status": "received"}
-		err = conn.WriteJSON(confirmMsg)
+		err = conn.WriteJSON(unityMsg)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## 概要
現状はandroid側からdifficultyをサーバーに送信したらUnity側にQuiz_idとAction_idが送信されるようになっていましたが，これを変更しました．
Android側には
```
{
 "status" : "recieved"
}
```
と言うデバッグメッセージのみ返答するようにしていたが，Unityに送るQuiz_idとAction_idのデータをAndroid側にも返すようにしました．
## 仕様
エンドポイント
```
/ws/difficult/android/{uuid}
```
送信するメッセージ
```
{
 "difficult": 1
 }
```

受信するメッセージ
```
{
 "quiz_id":[1,2,3],
 "action_id":1
}
```
これでゲーム中画面で問題表示するなど活用してください．(余裕があったら)